### PR TITLE
Remove local replace directive from go.mod

### DIFF
--- a/mdtest/go.mod
+++ b/mdtest/go.mod
@@ -16,5 +16,3 @@ require (
 	golang.org/x/crypto v0.0.0-20221012134737-56aed061732a // indirect
 	rsc.io/qr v0.2.0 // indirect
 )
-
-replace go.mau.fi/whatsmeow => ../


### PR DESCRIPTION
Replace directives disable external `go run ...` support:

```
% go run github.com/tulir/whatsmeow/mdtest@latest
go: github.com/tulir/whatsmeow/mdtest@latest (in github.com/tulir/whatsmeow/mdtest@v0.0.0-20221126173344-e660988acdbc):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
```

A better way to develop multiple modules concurrently is with Go 1.18 workspaces[0].

[0] https://go.dev/blog/get-familiar-with-workspaces